### PR TITLE
remove method not being used

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -21,12 +21,6 @@ class CommentsController < ApplicationController
     end
   end
 
-  def destroy
-    @post = Post.find(params[:post_id])
-    @comment = Comment.find(params[:id])
-    @comment.destroy
-  end
-
   def update
     @comment = Comment.find(params[:id])
     @comment.update(body: "deleted", user_id: nil)


### PR DESCRIPTION
Removes comment destroy method because the app never actually destroys a comment but rather replaces its text with 'deleted' and that method already exists.